### PR TITLE
Fix bugs with enterprise wifi and saving of config

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const commands = {
   wpaDisconnect: 'wpa_cli disconnect',
   wpaListInterfaces: 'wpa_cli interface',
   wpaInterface: 'wpa_cli interface :INTERFACE',
-  wpaList: 'wpa_cli list_networks -i ' + currentInterface
+  wpaList: 'wpa_cli list_networks -i :INTERFACE'
 };
 
 
@@ -477,7 +477,7 @@ function restartInterface(iface, callback) {
  * @param {function} callback (err, networksArray) returns err if the process fails, each network is a Json object that contains network_id, ssid, bssid and flags
  */
 function listNetworks(callback) {
-  exec(commands.wpaList, function (err, stdout) {
+  exec(replaceInCommand(commands.wpaList, { interface: currentInterface }), function (err, stdout) {
     var tempNetworkJson, parameters, networksArray;
 
     if (!err) {


### PR DESCRIPTION
- Enterprise wifi could not be saved because the phase1 and phase2 fields needs to be quoted like username and password.

-   phase1 was being forced to be set to the value of phase2.

- list_networks was not passing interface name and thus would never find the stuff that already existed in the wpa_supplicant.conf file. 

- Putting save as the last command in connectToId ensures the other networks are marked as disabled so that the device will connect to the correct network on reboot.